### PR TITLE
Feature: add default on to show switch, add sticky

### DIFF
--- a/frontend-vue/src/components/domains/ContextureDomainCardGrid.vue
+++ b/frontend-vue/src/components/domains/ContextureDomainCardGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="domains.length" class="sticky top-0 mb-4 border border-x-0 border-t-0 border-blue-100 bg-white pb-2">
+  <div v-if="domains.length" class="sticky top-0 mb-4 border border-x-0 border-t-0 border-blue-100 bg-white py-2">
     <ContextureSwitch
       v-model="options.showBadges"
       :label="t('domains.details.filter.show_bounded_contexts_and_subdomains')"

--- a/frontend-vue/src/components/domains/ContextureDomainCardGrid.vue
+++ b/frontend-vue/src/components/domains/ContextureDomainCardGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="domains.length" class="mb-4">
+  <div v-if="domains.length" class="sticky top-0 mb-4 border border-x-0 border-t-0 border-blue-100 bg-white pb-2">
     <ContextureSwitch
       v-model="options.showBadges"
       :label="t('domains.details.filter.show_bounded_contexts_and_subdomains')"
@@ -38,6 +38,6 @@ withDefaults(defineProps<Props>(), {
 
 const { t } = useI18n();
 const options: RemovableRef<DomainCardGridOptions> = useLocalStorage<DomainCardGridOptions>("settings.domains.grid", {
-  showBadges: false,
+  showBadges: true,
 });
 </script>

--- a/frontend-vue/src/components/primitives/switch/ContextureSwitch.vue
+++ b/frontend-vue/src/components/primitives/switch/ContextureSwitch.vue
@@ -12,7 +12,7 @@
           class="inline-block h-3 w-3 transform rounded-full bg-white transition"
         />
       </Switch>
-      <SwitchLabel class="ml-2 text-xs text-gray-600">
+      <SwitchLabel class="text-md ml-2 text-gray-800">
         {{ label }}
       </SwitchLabel>
     </div>


### PR DESCRIPTION
- changes default "show bounded contexts and subdomains" switch to **on**
- style text bigger with sticky style

<img width="688" alt="image" src="https://github.com/trustbit/Contexture/assets/14905547/86069d7b-3041-4046-a917-59d826dcd4d4">
<img width="493" alt="image" src="https://github.com/trustbit/Contexture/assets/14905547/8d3db220-fbf4-4cfc-885c-633bcf3a876b">
