### PR TITLE
CI/CD: sync main to master, update github action

### DIFF
--- a/.github/workflows/CI-frontend.yml
+++ b/.github/workflows/CI-frontend.yml
@@ -3,7 +3,7 @@
 name: CI-Frontend
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the master and main branch
 on:
   push:
     paths:

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
+      - main
   workflow_dispatch:
-
 
 # CONFIGURATION
 # For help, go to https://github.com/Azure/Actions
@@ -15,8 +15,8 @@ on:
 #
 # 2. Change these variables for your configuration:
 env:
-  AZURE_WEBAPP_NAME: contexture    # set this to your application's name
-  AZURE_WEBAPP_PACKAGE_PATH: './artifacts/image/'      # set this to the path to your web app project, defaults to the repository root
+  AZURE_WEBAPP_NAME: contexture # set this to your application's name
+  AZURE_WEBAPP_PACKAGE_PATH: './artifacts/image/' # set this to the path to your web app project, defaults to the repository root
   DOTNET_VERSION: '7.0.X'
 
 jobs:
@@ -24,27 +24,27 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-    - run: make build-backend
-      name: Build
-    - run: make test-backend
-      name: Test
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18.x'
-    - run: make prepare-image
-    - name: prepare scenario
-      run: cp ./example/restaurant-db.json ./artifacts/image/db.json
-    - name: 'Deploy to Azure WebApp'
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: ${{ env.AZURE_WEBAPP_NAME }}
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+      - uses: actions/checkout@master
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '7.0.x'
+      - run: make build-backend
+        name: Build
+      - run: make test-backend
+        name: Test
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: make prepare-image
+      - name: prepare scenario
+        run: cp ./example/restaurant-db.json ./artifacts/image/db.json
+      - name: 'Deploy to Azure WebApp'
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
   # For more information on GitHub Actions for Azure, refer to https://github.com/Azure/Actions
   # For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
     tags:
       - '*'
 jobs:
@@ -11,29 +12,29 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-    - run: make build-backend
-      name: Build
-    - run: make test-backend
-      name: Test
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18.x'
-    - run: make prepare-image
-      name: Prepares backend & frontend into an image
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@main
-      env:
-        GIT_HASH: ${{ github.sha }}
-      with:
-        name: softwarepark/contexture
-        workdir: artifacts/image
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: ../backend/Dockerfile
-        buildargs: GIT_HASH
-        tag_semver: true
+      - uses: actions/checkout@master
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '7.0.x'
+      - run: make build-backend
+        name: Build
+      - run: make test-backend
+        name: Test
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: make prepare-image
+        name: Prepares backend & frontend into an image
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@main
+        env:
+          GIT_HASH: ${{ github.sha }}
+        with:
+          name: softwarepark/contexture
+          workdir: artifacts/image
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: ../backend/Dockerfile
+          buildargs: GIT_HASH
+          tag_semver: true


### PR DESCRIPTION
#### Changes
- adds `main` branch
- updates GitHub Actions to include `main`branch 

#### Description
This PR represents a change in the default branch naming convention from master to main as part of our ongoing effort to use more inclusive language throughout our development practices.

#### Instructions for Team Members

For local repositories:
After this PR is merged, you will need to update your local clones to track the new main branch. You can do this by running the following commands in your local repository:

```bash
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```