### PR TITLE
feature: add dropdown autocomplete to namespaces

### DIFF
--- a/frontend-vue/package-lock.json
+++ b/frontend-vue/package-lock.json
@@ -15,6 +15,7 @@
         "@vueuse/core": "^9.12.0",
         "@vueuse/router": "^9.13.0",
         "d3": "^7.8.2",
+        "fuse.js": "^7.0.0",
         "pinia": "^2.0.32",
         "vee-validate": "^4.7.4",
         "vue": "^3.2.47",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.21.0",
+        "@fuse-open/types": "^2.7.1",
         "@iconify-json/material-symbols": "^1.1.32",
         "@intlify/unplugin-vue-i18n": "^0.8.2",
         "@playwright/test": "^1.30.0",
@@ -829,6 +831,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@fuse-open/types": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@fuse-open/types/-/types-2.7.1.tgz",
+      "integrity": "sha512-lnO0eeAUt+En3AAMmeenq2o3Q6izUreFEqVd9ePeccMz09XPyygnFx1BSAoy6UNEVcks1Ptuyy/Cy+8dZ/VrzQ==",
+      "dev": true
     },
     "node_modules/@headlessui/tailwindcss": {
       "version": "0.1.2",
@@ -4157,6 +4165,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -7937,6 +7953,12 @@
         "vue-demi": "^0.13.11"
       }
     },
+    "@fuse-open/types": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@fuse-open/types/-/types-2.7.1.tgz",
+      "integrity": "sha512-lnO0eeAUt+En3AAMmeenq2o3Q6izUreFEqVd9ePeccMz09XPyygnFx1BSAoy6UNEVcks1Ptuyy/Cy+8dZ/VrzQ==",
+      "dev": true
+    },
     "@headlessui/tailwindcss": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.1.2.tgz",
@@ -10416,6 +10438,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/frontend-vue/package.json
+++ b/frontend-vue/package.json
@@ -20,6 +20,7 @@
     "@vueuse/core": "^9.12.0",
     "@vueuse/router": "^9.13.0",
     "d3": "^7.8.2",
+    "fuse.js": "^7.0.0",
     "pinia": "^2.0.32",
     "vee-validate": "^4.7.4",
     "vue": "^3.2.47",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",
+    "@fuse-open/types": "^2.7.1",
     "@iconify-json/material-symbols": "^1.1.32",
     "@intlify/unplugin-vue-i18n": "^0.8.2",
     "@playwright/test": "^1.30.0",

--- a/frontend-vue/src/components/bounded-context/namespace/ContextureNamespace.vue
+++ b/frontend-vue/src/components/bounded-context/namespace/ContextureNamespace.vue
@@ -64,8 +64,7 @@
             :suggestions="boundedContextNameSuggestions"
             :display-value="(l: any) => l"
             :allow-custom-values="true"
-            @complete="searchKeySuggestions"
-            @keyup.enter="applyKeySuggestions($event.target.value, newLabel)"
+            @complete="searchKeySuggestions($event, newLabel)"
           ></ContextureAutocomplete>
 
           <div class="ml-4">
@@ -161,13 +160,10 @@ watch(
   }
 );
 
-function searchKeySuggestions(query: string): void {
+function searchKeySuggestions(query: string, newLabel: { value?: string; name: string; template?: string }): void {
   const results = fuse.search(query);
   boundedContextNameSuggestions.value = results.map((result: { item: string }) => result.item);
-}
 
-function applyKeySuggestions(query: string, newLabel: { value: string; name: string }): void {
-  const results = fuse.search(query);
   if (results.length > 0) {
     newLabel.value = results[0].item;
   }

--- a/frontend-vue/src/components/bounded-context/namespace/ContextureNamespace.vue
+++ b/frontend-vue/src/components/bounded-context/namespace/ContextureNamespace.vue
@@ -55,13 +55,19 @@
             :placeholder="t('common.name')"
             :skip-validation="true"
           ></ContextureInputText>
-          <ContextureInputText
+
+          <ContextureAutocomplete
             v-model="newLabel.value"
-            :name="`newLabelValue-${index}`"
             class="ml-2 grow"
+            :name="`newLabelValue-${index}`"
             :placeholder="t('common.value')"
-            :skip-validation="true"
-          ></ContextureInputText>
+            :suggestions="boundedContextNameSuggestions"
+            :display-value="(l: any) => l"
+            :allow-custom-values="true"
+            @complete="searchKeySuggestions"
+            @keyup.enter="applyKeySuggestions($event.target.value, newLabel)"
+          ></ContextureAutocomplete>
+
           <div class="ml-4">
             <ContextureTextLinkButton @click.prevent="() => onDeleteNewLabel(index)">
               <template #left>
@@ -98,15 +104,20 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
+import Fuse from "fuse.js";
+
 import ContextureAccordionItem from "~/components/primitives/accordion/ContextureAccordionItem.vue";
+import ContextureAutocomplete from "~/components/primitives/autocomplete/ContextureAutocomplete.vue";
 import ContexturePrimaryButton from "~/components/primitives/button/ContexturePrimaryButton.vue";
 import ContextureTextLinkButton from "~/components/primitives/button/ContextureTextLinkButton.vue";
 import ContextureWhiteButton from "~/components/primitives/button/ContextureWhiteButton.vue";
 import ContextureInputText from "~/components/primitives/input/ContextureInputText.vue";
 import ContextureListItem from "~/components/primitives/list/ContextureListItem.vue";
+
 import { CreateNamespaceLabel, Namespace, NamespaceLabel } from "~/types/namespace";
+import { useDomainsStore } from "~/stores/domains";
 
 interface Props {
   namespace: Namespace;
@@ -126,6 +137,41 @@ const { t } = useI18n();
 const newLabels = ref<CreateNamespaceLabel[]>([]);
 const editMode = ref(false);
 const showEmptyMessage = computed(() => props.namespace.labels.length === 0 && !editMode.value);
+const domainStore = useDomainsStore();
+const boundedContextNameSuggestions = ref<string[]>([]);
+
+const fuseOptions = {
+  shouldSort: true,
+  threshold: 0.6,
+  location: 0,
+  distance: 100,
+  maxPatternLength: 32,
+  minMatchCharLength: 1,
+  includeScore: true,
+  keys: ["name"],
+};
+
+let fuse: Fuse<string> = new Fuse(boundedContextNameSuggestions.value, fuseOptions);
+
+watch(
+  () => domainStore.allBoundedContextsNames,
+  (newVal) => {
+    boundedContextNameSuggestions.value = newVal;
+    fuse = new Fuse(boundedContextNameSuggestions.value, fuseOptions);
+  }
+);
+
+function searchKeySuggestions(query: string): void {
+  const results = fuse.search(query);
+  boundedContextNameSuggestions.value = results.map((result: { item: string }) => result.item);
+}
+
+function applyKeySuggestions(query: string, newLabel: { value: string; name: string }): void {
+  const results = fuse.search(query);
+  if (results.length > 0) {
+    newLabel.value = results[0].item;
+  }
+}
 
 function addNewLabel() {
   newLabels.value = [...newLabels.value, { name: "" }];

--- a/frontend-vue/src/stores/domains.ts
+++ b/frontend-vue/src/stores/domains.ts
@@ -1,6 +1,6 @@
 import { UseFetchReturn } from "@vueuse/core";
 import { defineStore } from "pinia";
-import { computed, onMounted, Ref, ref } from "vue";
+import { computed, onMounted, Ref, ref, watch } from "vue";
 import { useFetch } from "~/composables/useFetch";
 import { CreateDomain, Domain, DomainId, UpdateDomain } from "~/types/domain";
 
@@ -172,6 +172,18 @@ export const useDomainsStore = defineStore("domains", () => {
     return domainLevel !== undefined && domainLevel > 0;
   };
 
+  const allBoundedContextsNames = computed(() => {
+    return allDomains.value
+      .filter((d) => d.boundedContexts.length > 0)
+      .map((d) => d.boundedContexts)
+      .map((bc) => bc.map((b) => b.name))
+      .flat();
+  });
+
+  watch(allDomains, () => {
+    allBoundedContextsNames.value;
+  });
+
   onMounted(fetchDomains);
 
   return {
@@ -183,6 +195,7 @@ export const useDomainsStore = defineStore("domains", () => {
     domainByDomainId,
     domainsLevelMap,
     maxSubdomainsLevel,
+    allBoundedContextsNames,
     deleteDomain,
     moveDomain,
     createDomain,

--- a/frontend-vue/tsconfig.json
+++ b/frontend-vue/tsconfig.json
@@ -14,19 +14,10 @@
     "strictNullChecks": true,
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
-    "types": [
-      "vite/client",
-      "vite-plugin-pages/client",
-      "unplugin-icons/types/vue",
-    ],
+    "types": ["vite/client", "vite-plugin-pages/client", "unplugin-icons/types/vue", "@fuse-open/types"],
     "paths": {
       "~/*": ["src/*"]
     }
   },
-  "exclude": [
-    "dist",
-    "node_modules",
-    "postcss.config.js",
-    "tailwind.config.cjs"
-  ]
+  "exclude": ["dist", "node_modules", "postcss.config.js", "tailwind.config.cjs"]
 }


### PR DESCRIPTION
This change adds Pre-filled entries for the drop down lists in “Namespaces”.
With the pre-filled list of options data will have a more consistent name across the namespaces and provide upfront review of the current names used in namespaces.

The UX logic implemented autocompletes with the first most likely suggestion, its easily overwriting using mouse or keys to select the inputed namespace value.

<img width="1326" alt="image" src="https://github.com/trustbit/Contexture/assets/14905547/64718f83-51fe-4187-af58-a3cabb1482d0">


In the next example:

 `bounded context1` name already exists in the namespaces, and the `bounded context2`name is the new name. 

The autocomplete dropdown selects the already existing name over the new one.

  
<img width="1315" alt="image" src="https://github.com/trustbit/Contexture/assets/14905547/89cbb05d-5b18-486c-86c2-245173d127b2">
