### PR TITLE
Dockerfile custom entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ publish-app: build-app
 prepare-image: publish-docker publish-app
 	mkdir -p artifacts/image/wwwroot
 	cp -r artifacts/backend/*.* artifacts/image/
+	cp entrypoint.sh artifacts/image/entrypoint.sh
 	cp -r artifacts/frontend/** artifacts/image/wwwroot/
 
 build-image: prepare-image

--- a/backend/Contexture.Api/Dockerfile
+++ b/backend/Contexture.Api/Dockerfile
@@ -7,4 +7,5 @@ LABEL org.opencontainers.image.revision=$GIT_HASH
 ENV ASPNETCORE_URLS=http://*:3000
 ENV FileBased__Path=/data/db.json
 ENV GitHash=$GIT_HASH
-ENTRYPOINT ["dotnet", "Contexture.Api.App.dll"]
+RUN ["chmod", "+x", "./entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+update-ca-certificates
+dotnet Contexture.Api.App.dll


### PR DESCRIPTION
Runs `update-ca-certificates` before starting Contexture.API

Motivation for this change is to make it possible to install certificates without the need of building a new image
it enables mounting a volume with certificates to be installed.
`-v /certificates-to-install:/usr/local/share/ca-certificates`