### PR TITLE
handle expired access token event

### DIFF
--- a/frontend-vue/src/stores/auth.ts
+++ b/frontend-vue/src/stores/auth.ts
@@ -75,8 +75,12 @@ export const useAuthStore = defineStore("auth", () => {
       userManager = new UserManager(settings);
       enabled.value = true;
 
-      Log.setLogger(console);
-      userManager.events.addSilentRenewError(async (_error) => {
+      userManager.events.addSilentRenewError(async () => {
+        await userManager.removeUser();
+        await userManager.signinRedirect();
+      });
+
+      userManager.events.addAccessTokenExpired(async () => {
         await userManager.removeUser();
         await userManager.signinRedirect();
       });

--- a/frontend-vue/src/stores/auth.ts
+++ b/frontend-vue/src/stores/auth.ts
@@ -1,4 +1,4 @@
-import { Log, UserManager, UserManagerSettings, WebStorageStateStore } from "oidc-client-ts";
+import { UserManager, UserManagerSettings, WebStorageStateStore } from "oidc-client-ts";
 import { defineStore } from "pinia";
 import { Ref, computed, inject, onMounted, ref } from "vue";
 import { AfterFetchContext, createFetch } from "@vueuse/core";


### PR DESCRIPTION
In case refresh token is already expired oidc-ts won't attempt to renew token so no renew error event is triggered instead we fallback to access token expired event. 