### PR TITLE
BoundedContext short name validation

### DIFF
--- a/frontend-vue/src/components/bounded-context/canvas/BCCKey.vue
+++ b/frontend-vue/src/components/bounded-context/canvas/BCCKey.vue
@@ -10,7 +10,7 @@
     <div v-if="editMode">
       <ContextureHelpfulErrorAlert v-if="submitError" v-bind="submitError" class="mb-4" />
       <Form @submit="onUpdate">
-        <ContextureChangeKey v-model="key" />
+        <ContextureInputText v-model="key" :rules="boundedContextShortNameValidator" />
 
         <ContexturePrimaryButton type="submit" :label="t('common.save')" class="mt-4" size="sm">
           <template #left>
@@ -27,28 +27,38 @@
 </template>
 
 <script setup lang="ts">
+import { toFieldValidator } from "@vee-validate/zod";
 import { storeToRefs } from "pinia";
 import { Form } from "vee-validate";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 import ContextureBoundedContextCanvasElement from "~/components/bounded-context/canvas/ContextureBoundedContextCanvasElement.vue";
-import ContextureChangeKey from "~/components/core/change-short-name/ContextureChangeShortName.vue";
+import { boundedContextShortNameValidationSchema } from "~/components/core/change-short-name/changeShortNameValidationSchema";
+("~/components/core/change-short-name/changeShortNameValidationSchema");
 import ContextureHelpfulErrorAlert, {
   HelpfulErrorProps,
 } from "~/components/primitives/alert/ContextureHelpfulErrorAlert.vue";
 import ContexturePrimaryButton from "~/components/primitives/button/ContexturePrimaryButton.vue";
+import ContextureInputText from "~/components/primitives/input/ContextureInputText.vue";
 import { useAuthStore } from "~/stores/auth";
 import { useBoundedContextsStore } from "~/stores/boundedContexts";
 import IconsMaterialSymbolsFormatKeyOutline from "~icons/material-symbols/key-outline";
 
 const icon = IconsMaterialSymbolsFormatKeyOutline;
 const store = useBoundedContextsStore();
-const { activeBoundedContext } = storeToRefs(store);
+const { activeBoundedContext, boundedContextsByDomainId } = storeToRefs(store);
 const { canModify } = useAuthStore();
 const { t } = useI18n();
 const key = ref(activeBoundedContext.value.shortName);
 const submitError = ref<HelpfulErrorProps | undefined>();
 const editMode = ref(false);
+const boundedContextShortNameValidator = toFieldValidator(
+  boundedContextShortNameValidationSchema(
+    boundedContextsByDomainId.value[activeBoundedContext.value.parentDomainId].filter(
+      (bc) => bc.id !== activeBoundedContext.value.id
+    )
+  )
+);
 
 async function onUpdate() {
   submitError.value = null;

--- a/frontend-vue/src/components/core/change-short-name/ContextureChangeShortName.vue
+++ b/frontend-vue/src/components/core/change-short-name/ContextureChangeShortName.vue
@@ -14,7 +14,6 @@ import { toFieldValidator } from "@vee-validate/zod";
 import { storeToRefs } from "pinia";
 import { shortNameValidationSchema } from "~/components/core/change-short-name/changeShortNameValidationSchema";
 import ContextureInputText from "~/components/primitives/input/ContextureInputText.vue";
-import { useBoundedContextsStore } from "~/stores/boundedContexts";
 import { useDomainsStore } from "~/stores/domains";
 
 interface Props {
@@ -25,11 +24,8 @@ const props = defineProps<Props>();
 const emit = defineEmits(["update:modelValue"]);
 
 const { allDomains } = storeToRefs(useDomainsStore());
-const { boundedContexts } = storeToRefs(useBoundedContextsStore());
 
-const shortNameValidationRules = toFieldValidator(
-  shortNameValidationSchema(props.modelValue, allDomains.value, boundedContexts.value)
-);
+const shortNameValidationRules = toFieldValidator(shortNameValidationSchema(props.modelValue, allDomains.value));
 
 console.log(shortNameValidationRules);
 

--- a/frontend-vue/src/components/core/change-short-name/changeShortNameValidationSchema.spec.ts
+++ b/frontend-vue/src/components/core/change-short-name/changeShortNameValidationSchema.spec.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { shortNameValidationSchema } from "~/components/core/change-short-name/changeShortNameValidationSchema";
+import {
+  shortNameValidationSchema,
+  boundedContextShortNameValidationSchema,
+} from "~/components/core/change-short-name/changeShortNameValidationSchema";
 
 describe("change short name validation rules", () => {
   test.each(["", null, undefined])("'%s' can not be null or empty", (shortName) => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse(shortName);
 
@@ -11,7 +14,7 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot exceed 16 characters", () => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse("a".repeat(17));
 
@@ -19,7 +22,7 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot contain whitespace", () => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse("a b");
 
@@ -27,7 +30,7 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot start with a number", () => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse("1a");
 
@@ -35,7 +38,7 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot start with hyphen", () => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse("-a");
 
@@ -43,7 +46,7 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot end with hyphen", () => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse("a-");
 
@@ -51,7 +54,7 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot contain characters other than alphanumeric and hyphen", () => {
-    const validation = shortNameValidationSchema("", [], []);
+    const validation = shortNameValidationSchema("", []);
 
     const { success } = validation.safeParse("a/b");
 
@@ -59,99 +62,85 @@ describe("change short name validation rules", () => {
   });
 
   test("cannot be the same as another domain", () => {
-    const validation = shortNameValidationSchema(
-      "",
-      [
-        {
-          id: "1",
-          name: "Domain",
-          shortName: "d",
-          subdomains: [],
-          boundedContexts: [],
-        },
-      ],
-      []
-    );
+    const validation = shortNameValidationSchema("", [
+      {
+        id: "1",
+        name: "Domain",
+        shortName: "d",
+        subdomains: [],
+        boundedContexts: [],
+      },
+    ]);
 
     const { success } = validation.safeParse("d");
 
     expect(success).toBeFalsy();
   });
 
-  test("cannot be the same as another bounded context", () => {
-    const validation = shortNameValidationSchema(
-      "",
-      [],
-      [
-        {
-          id: "2",
-          shortName: "bc",
-          name: "Bounded Context",
-          parentDomainId: "1",
-          classification: {},
-          businessDecisions: [],
-          namespaces: [],
-          ubiquitousLanguage: {},
-          domain: {
-            id: "1",
-            name: "Domain",
-            subdomains: [],
-            boundedContexts: [],
-          },
-        },
-      ]
-    );
-
-    const { success } = validation.safeParse("bc");
-
-    expect(success).toBeFalsy();
-  });
-
   test("cannot be the same as another domain (case insensitive)", () => {
-    const validation = shortNameValidationSchema(
-      "",
-      [
-        {
-          id: "1",
-          name: "Domain",
-          shortName: "d",
-          subdomains: [],
-          boundedContexts: [],
-        },
-      ],
-      []
-    );
+    const validation = shortNameValidationSchema("", [
+      {
+        id: "1",
+        name: "Domain",
+        shortName: "d",
+        subdomains: [],
+        boundedContexts: [],
+      },
+    ]);
 
     const { success } = validation.safeParse("D");
 
     expect(success).toBeFalsy();
   });
+});
 
+describe("bounded context short name validation rules", () => {
   test("cannot be the same as another bounded context (case insensitive)", () => {
-    const validation = shortNameValidationSchema(
-      "",
-      [],
-      [
-        {
-          id: "2",
-          shortName: "bc",
-          name: "Bounded Context",
-          parentDomainId: "1",
-          classification: {},
-          businessDecisions: [],
-          namespaces: [],
-          ubiquitousLanguage: {},
-          domain: {
-            id: "1",
-            name: "Domain",
-            subdomains: [],
-            boundedContexts: [],
-          },
+    const validation = boundedContextShortNameValidationSchema([
+      {
+        id: "2",
+        shortName: "bc",
+        name: "Bounded Context",
+        parentDomainId: "1",
+        classification: {},
+        businessDecisions: [],
+        namespaces: [],
+        ubiquitousLanguage: {},
+        domain: {
+          id: "1",
+          name: "Domain",
+          subdomains: [],
+          boundedContexts: [],
         },
-      ]
-    );
+      },
+    ]);
 
     const { success } = validation.safeParse("BC");
+
+    expect(success).toBeFalsy();
+  });
+
+  test("cannot be the same as another bounded context", () => {
+    const validation = boundedContextShortNameValidationSchema([
+      {
+        id: "2",
+        shortName: "bc",
+        name: "Bounded Context",
+        parentDomainId: "1",
+        classification: {},
+        businessDecisions: [],
+        namespaces: [],
+        ubiquitousLanguage: {},
+        domain: {
+          id: "1",
+          name: "Domain",
+          subdomains: [],
+          boundedContexts: [],
+        },
+      },
+    ]);
+
+    const { success } = validation.safeParse("bc");
 
     expect(success).toBeFalsy();
   });

--- a/frontend-vue/src/components/core/change-short-name/changeShortNameValidationSchema.ts
+++ b/frontend-vue/src/components/core/change-short-name/changeShortNameValidationSchema.ts
@@ -6,11 +6,7 @@ import { Domain } from "~/types/domain";
 
 const allowedCharacters: string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-";
 
-export const shortNameValidationSchema = (
-  currentShortName: string | undefined,
-  domains: Domain[],
-  boundedContexts: BoundedContext[]
-) =>
+export const shortNameValidationSchema = (currentShortName: string | undefined, domains: Domain[]) =>
   zod
     .string()
     .min(1)
@@ -20,16 +16,6 @@ export const shortNameValidationSchema = (
         in: domains.filter((d) => d.shortName !== currentShortName),
         field: "shortName",
         errorMessage: `The short name '${arg}' is already in use by domain '${mapDomain(arg, domains)}'`,
-      });
-    })
-    .superRefine((arg: string, ctx: RefinementCtx) => {
-      isUniqueIn<BoundedContext>(arg, ctx, {
-        in: boundedContexts.filter((bc) => bc.shortName !== currentShortName),
-        field: "shortName",
-        errorMessage: `The short name '${arg}' is already in use by bounded context '${mapBoundedContext(
-          arg,
-          boundedContexts
-        )}'`,
       });
     })
     .refine((term: string) => !startsWithNumber(term), {
@@ -51,7 +37,34 @@ function mapDomain(prop: string, domains: Domain[]): string {
   return `${domain?.name}-${domain?.shortName}`;
 }
 
-function mapBoundedContext(prop: string, boundedContexts: BoundedContext[]): string {
-  const bc = boundedContexts.find((bc) => bc.shortName?.toUpperCase() === prop.toUpperCase());
-  return `${bc?.name}-${bc?.shortName}`;
-}
+export const boundedContextShortNameValidationSchema = (boundedContexts: BoundedContext[]) =>
+  zod
+    .string()
+    .min(1)
+    .max(16)
+    .refine((term: string) => !startsWithNumber(term), {
+      message: "Must not start with a number",
+    })
+    .refine((term: string) => !contains(term, " "), {
+      message: "Must not contain whitespace",
+    })
+    .refine((term: string) => !startsWith(term, "-"), {
+      message: "Must not start with hyphen",
+    })
+    .refine((term: string) => !endsWith(term, "-"), { message: "Must not end with hyphen" })
+    .refine((term: string) => term.split("").every((c) => allowedCharacters.includes(c)), {
+      message: "Must only contain alphanumeric characters and hyphens",
+    })
+    .refine(
+      (term: string) => {
+        const bc = boundedContexts.find((bc) => bc.shortName?.toLocaleLowerCase() === term?.toLocaleLowerCase());
+        if (bc) return false;
+        else return true;
+      },
+      (term: string) => {
+        const bc = boundedContexts.find((bc) => bc.shortName?.toLocaleLowerCase() === term?.toLocaleLowerCase());
+        return {
+          message: `The short name '${term}' is already in use by bounded context '${bc?.name}-${bc?.shortName}'`,
+        };
+      }
+    );

--- a/frontend-vue/src/components/domains/details/ContextureCreateBoundedContextModal.vue
+++ b/frontend-vue/src/components/domains/details/ContextureCreateBoundedContextModal.vue
@@ -30,7 +30,7 @@ import ContextureModal from "~/components/primitives/modal/ContextureModal.vue";
 import { useBoundedContextsStore } from "~/stores/boundedContexts";
 import { Domain } from "~/types/domain";
 import { CreateBoundedContext } from "~/types/boundedContext";
-import ContextureChangeKey from "~/components/core/change-short-name/ContextureChangeShortName.vue";
+import { boundedContextShortNameValidationSchema } from "~/components/core/change-short-name/changeShortNameValidationSchema";
 
 interface Props {
   isOpen: boolean;
@@ -46,7 +46,6 @@ const emit = defineEmits<Emits>();
 const { t } = useI18n();
 const router = useRouter();
 const { createBoundedContext } = useBoundedContextsStore();
-
 const form: DynamicFormSchema<CreateBoundedContext> = {
   fields: [
     {
@@ -61,10 +60,12 @@ const form: DynamicFormSchema<CreateBoundedContext> = {
     },
     {
       name: "shortName",
-      component: ContextureChangeKey,
+      component: ContextureInputText,
       componentProps: {
         label: t("domains.modal.create_bounded_context.form.fields.short_name.label"),
         description: t("bounded_context_canvas.edit.form.description.key"),
+        required: true,
+        rules: toFieldValidator(boundedContextShortNameValidationSchema(props.parentDomain.boundedContexts)),
       },
     },
     {

--- a/frontend-vue/src/stores/domains.ts
+++ b/frontend-vue/src/stores/domains.ts
@@ -76,21 +76,27 @@ export const useDomainsStore = defineStore("domains", () => {
     const oldValue = domainByDomainId.value[domainId];
     const response = [];
     if (oldValue.shortName !== update.key) {
-      response.push(await useFetch<Domain>(`/api/domains/${domainId}/shortName`).post({
-        shortName: update.key,
-      }));
+      response.push(
+        await useFetch<Domain>(`/api/domains/${domainId}/shortName`).post({
+          shortName: update.key,
+        })
+      );
     }
 
     if (oldValue.vision !== update.vision) {
-      response.push(await useFetch<Domain>(`/api/domains/${domainId}/vision`).post({
-        vision: update.vision,
-      }));
+      response.push(
+        await useFetch<Domain>(`/api/domains/${domainId}/vision`).post({
+          vision: update.vision,
+        })
+      );
     }
 
     if (oldValue.name !== update?.name) {
-      response.push(await useFetch<Domain>(`/api/domains/${domainId}/rename`).post({
-        name: update.name,
-      }));
+      response.push(
+        await useFetch<Domain>(`/api/domains/${domainId}/rename`).post({
+          name: update.name,
+        })
+      );
     }
     if (response.find((r) => !r.response.value?.ok)) {
       return response;


### PR DESCRIPTION
Changes scope of uniqueness constraint for bounded context short name 
has to be unique only within particular domain/sub-domain and isn't checked recursively.

Fixes bug where short name constraint wasn't checked correctly when editing bounded context