### PR TITLE
Health based on subscriptions health

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ Your data will be stored in the `/data/db.json` file on the volume `/data`.
 
 ### Liveness & Readiness Probes
 
-Contexture provides HTTP based [Liveness & Readiness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) to determine if the container is health & operational
+Contexture provides HTTP based [Liveness & Readiness Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) to determine if the container is healthy & operational
 
 #### Liveness
 
 A `GET` request to `$BASE_URL/meta/health` will return `200 OK` if the application is healthy and currently processing requests.
+It will return a `503 ServiceUnavailable` in case information about subscriptions can not be obtained or any of the subscriptions have Failed.
 
 #### Readiness
 

--- a/backend/Contexture.Api/Infrastructure/NStoreBased.fs
+++ b/backend/Contexture.Api/Infrastructure/NStoreBased.fs
@@ -395,7 +395,11 @@ type Storage(persistence: IPersistence, clock: Clock, logger: INStoreLoggerFacto
             return
                 { new Subscription with
                     member _.Name = name
-                    member _.Status = status ()
+                    member _.Status =
+                        if pollingClient.IsActive then
+                            status ()
+                        else
+                            Stopped (Position.from pollingClient.Position)
                     member _.DisposeAsync() = ValueTask(pollingClient.Stop()) }
         }
 


### PR DESCRIPTION
Service reports healthy when all subscriptions are Processing or CaughtUp - assumption here is that there's no way to manually start/stop the subscription and they should always process messages