### PR TITLE
Add support for filtering nested objects

### DIFF
--- a/frontend-vue/src/core/filter.spec.ts
+++ b/frontend-vue/src/core/filter.spec.ts
@@ -37,4 +37,21 @@ describe("filter", () => {
 
     expect(actualFound).toBeFalsy();
   });
+
+  it("should search in nested object array", () => {
+    const nestedObject = {
+      a: [
+        {
+          b: [
+            {
+              c: "hit",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = filter(nestedObject, "hit");
+    expect(result).toBeTruthy();
+  });
 });

--- a/frontend-vue/src/core/filter.ts
+++ b/frontend-vue/src/core/filter.ts
@@ -21,8 +21,7 @@ export function filter(obj: any, query: string, key?: string | undefined): boole
       if (nestedResults.length) {
         return true;
       }
-    }
-    else if (typeof propValue === "object") {
+    } else if (typeof propValue === "object") {
       return filter(propValue, query);
     } else if (typeof propValue === "string") {
       if (propValue.toLowerCase().includes(query?.toLowerCase())) {

--- a/frontend-vue/src/core/filter.ts
+++ b/frontend-vue/src/core/filter.ts
@@ -6,24 +6,27 @@
  * @param key An optional property key to limit the search to
  * @returns Returns a boolean indicating if the query was found in any of the object's properties.
  */
-export function filter(obj: any, query: string, key?: string | undefined) {
+export function filter(obj: any, query: string, key?: string | undefined): boolean {
   for (const prop in obj) {
     if (key && prop !== key) {
       continue;
     }
-    if (Array.isArray(obj[prop])) {
-      if (obj[prop].includes(query)) {
+    const propValue = obj[prop];
+    if (!propValue) return false;
+    if (Array.isArray(propValue)) {
+      if (propValue.includes(query)) {
         return true;
       }
-      const nestedResults = filterInArray(obj[prop] as any[], query);
+      const nestedResults = filterInArray(propValue as any[], query);
       if (nestedResults.length) {
         return true;
       }
-    } else {
-      if (typeof obj[prop] === "string") {
-        if (obj[prop].toLowerCase().includes(query?.toLowerCase())) {
-          return true;
-        }
+    }
+    else if (typeof propValue === "object") {
+      return filter(propValue, query);
+    } else if (typeof propValue === "string") {
+      if (propValue.toLowerCase().includes(query?.toLowerCase())) {
+        return true;
       }
     }
   }


### PR DESCRIPTION
This PR extends the existing filter functionality to support nested object filtering. Previously, the filter only worked on arrays and direct string properties, but nested objects were ignored.

**Changes made:**
- Added recursion within filter to handle properties that are objects.
- Specified an explicit return type (boolean) for the filter function, enhancing type clarity.