### PR TITLE
feat(filter): enable parent domain search support

### DIFF
--- a/frontend-vue/src/components/primitives/input/ContextureSearch.vue
+++ b/frontend-vue/src/components/primitives/input/ContextureSearch.vue
@@ -16,7 +16,7 @@
       @input="onInput"
     />
     <div v-if="modelValue" class="absolute inset-y-0 right-0 flex cursor-pointer items-center pr-3" @click="clear">
-      <Icon:materialSymbols:close class="h-5 w-5 text-blue-500 hover:text-blue-400" />
+      <Icon:materialSymbols:close class="h-5 w-5 text-blue-500 hover:text-blue-400 bg-white" />
     </div>
   </div>
 </template>

--- a/frontend-vue/src/core/filter.ts
+++ b/frontend-vue/src/core/filter.ts
@@ -22,7 +22,9 @@ export function filter(obj: any, query: string, key?: string | undefined): boole
         return true;
       }
     } else if (typeof propValue === "object") {
-      return filter(propValue, query);
+      if (filter(propValue, query)) {
+        return true;
+      }
     } else if (typeof propValue === "string") {
       if (propValue.toLowerCase().includes(query?.toLowerCase())) {
         return true;

--- a/frontend-vue/src/pages/search/Search.vue
+++ b/frontend-vue/src/pages/search/Search.vue
@@ -24,7 +24,7 @@
 
           <div class="mt-8 flex flex-col gap-y-4">
             <template v-for="parentDomain of sortedParentDomains" :key="parentDomain.id">
-              <div class="grid-cols-3 gap-4 bg-gray-100 p-2 sm:grid sm:p-6" v-if="showParentDomain(parentDomain.id)">
+              <div class="grid-cols-3 gap-4 bg-gray-100 p-2 sm:grid sm:p-6" v-if="showParentDomain(parentDomain)">
                 <!-- parent domains -->
                 <!-- first column -->
                 <RouterLink
@@ -325,8 +325,7 @@ import { useBoundedContextsStore } from "~/stores/boundedContexts";
 import { useDomainsStore } from "~/stores/domains";
 import { refDebounced, useLocalStorage } from "@vueuse/core";
 import { BoundedContext } from "~/types/boundedContext";
-import { Domain } from "~/types/domain";
-import { DomainId } from "~/types/domain";
+import { Domain, DomainId } from "~/types/domain";
 
 interface DomainListViewSettings {
   showDescription: boolean;
@@ -419,9 +418,13 @@ const searchInBoundedContext = (
   }, {});
 };
 
-const showParentDomain = (parentDomainId: DomainId) => {
-  return searchQuery.value
-    ? filteredSubdomains.value[parentDomainId]?.length > 0 || filteredBoundedContexts.value[parentDomainId]?.length > 0
-    : filteredSubdomains;
+const showParentDomain = (parentDomain: Domain) => {
+  if (!searchQuery.value) return filteredSubdomains;
+  const parentDomainId: DomainId = parentDomain.id;
+  return (
+    filteredSubdomains.value[parentDomainId]?.length > 0 ||
+    filteredBoundedContexts.value[parentDomainId]?.length > 0 ||
+    filter({ ...parentDomain, boundedContexts: [], subdomains: [] }, searchQuery.value)
+  );
 };
 </script>


### PR DESCRIPTION
Added functionality to allow filtering by parent domains, making it easier to search for related subdomains or bc's. 
